### PR TITLE
Add missing cstdint

### DIFF
--- a/include/zep/mcommon/math/math.h
+++ b/include/zep/mcommon/math/math.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cmath>
+#include <cstdint>
 #include <ostream>
 #include <algorithm>
 

--- a/include/zep/mcommon/string/stringutils.h
+++ b/include/zep/mcommon/string/stringutils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <ostream>
 #include <sstream>


### PR DESCRIPTION
# Description

Compilation was failing as `uint` types were being used without importing `cstdint`. There was one instance in `pcsx-redux` as well that is fixed in a separate PR

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* OS: Arch Linux

# Checklist:

- [x] My code has been formatted with the clang format file
- [x] New and existing unit tests pass locally with my changes
- [x] Qt and ImGui demo projects function correctly
