### PR TITLE
unittests: fix ZepDisplay() call

### DIFF
--- a/src/tests/buffer.test.cpp
+++ b/src/tests/buffer.test.cpp
@@ -14,7 +14,7 @@ public:
     {
         // Disable threads for consistent tests, at the expense of not catching thread errors!
         // TODO : Fix/understand test failures with threading
-        spEditor = std::make_shared<ZepEditor>(new ZepDisplayNull(NVec2f(1.0f, 1.0f)), ZEP_ROOT, ZepEditorFlags::DisableThreads);
+        spEditor = std::make_shared<ZepEditor>(new ZepDisplayNull(), ZEP_ROOT, ZepEditorFlags::DisableThreads);
         pBuffer = spEditor->InitWithText("", "");
     }
 

--- a/src/tests/mode_standard.test.cpp
+++ b/src/tests/mode_standard.test.cpp
@@ -18,7 +18,7 @@ public:
     {
         // Disable threads for consistent tests, at the expense of not catching thread errors!
         // TODO : Fix/understand test failures with threading
-        spEditor = std::make_shared<ZepEditor>(new ZepDisplayNull(NVec2f(1.0f, 1.0f)), ZEP_ROOT, ZepEditorFlags::DisableThreads);
+        spEditor = std::make_shared<ZepEditor>(new ZepDisplayNull(), ZEP_ROOT, ZepEditorFlags::DisableThreads);
         pBuffer = spEditor->InitWithText("Test Buffer", "");
 
         pTabWindow = spEditor->GetActiveTabWindow();

--- a/src/tests/mode_vim.test.cpp
+++ b/src/tests/mode_vim.test.cpp
@@ -24,7 +24,7 @@ public:
     {
         // Disable threads for consistent tests, at the expense of not catching thread errors!
         // TODO : Fix/understand test failures with threading
-        spEditor = std::make_shared<ZepEditor>(new ZepDisplayNull(NVec2f(1.0f, 1.0f)), ZEP_ROOT, ZepEditorFlags::DisableThreads);
+        spEditor = std::make_shared<ZepEditor>(new ZepDisplayNull(), ZEP_ROOT, ZepEditorFlags::DisableThreads);
         spMode = std::make_shared<ZepMode_Vim>(*spEditor);
         spMode->Init();
 

--- a/src/tests/syntax.test.cpp
+++ b/src/tests/syntax.test.cpp
@@ -13,7 +13,7 @@ class SyntaxTest : public testing::Test
 public:
     SyntaxTest()
     {
-        spEditor = std::make_shared<ZepEditor>(new ZepDisplayNull(NVec2f(1.0f, 1.0f)), ZEP_ROOT, ZepEditorFlags::DisableThreads);
+        spEditor = std::make_shared<ZepEditor>(new ZepDisplayNull(), ZEP_ROOT, ZepEditorFlags::DisableThreads);
     }
 
     ~SyntaxTest()


### PR DESCRIPTION
Currently the unit tests don't build because 97b4365ff9300abc64801e3dc96b27693bc9228a removed the pixelScale parameter from ZepDisplay's constructor:

```
/project/zep$ make -C build unittests
make: Entering directory '/project/zep/build'
/project/zep/src/tests/buffer.test.cpp: In constructor ‘BufferTest::BufferTest()’:
/project/zep/src/tests/buffer.test.cpp:17:85: error: no matching function for call to ‘Zep::ZepDisplayNull::ZepDisplayNull(Zep::NVec2f)’
   17 |         spEditor = std::make_shared<ZepEditor>(new ZepDisplayNull(NVec2f(1.0f, 1.0f)), ZEP_ROOT, ZepEditorFlags::DisableThreads);
      |                                                                                     ^
```